### PR TITLE
feat: add Prometheus + Grafana monitoring stack

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=30d'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ALLOW_EMBEDDING=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'api-server'
+    static_configs:
+      - targets: ['10.30.0.2:9100']  # TODO: update with actual API server IP
+        labels:
+          server: 'api'
+
+  - job_name: 'dev-server'
+    static_configs:
+      - targets: ['10.10.0.2:9100']  # TODO: update with actual Dev server IP
+        labels:
+          server: 'dev'
+
+  - job_name: 'prod-server'
+    static_configs:
+      - targets: ['10.20.0.2:9100']  # TODO: update with actual Prod server IP
+        labels:
+          server: 'prod'


### PR DESCRIPTION
## What
Add Docker Compose configuration for Prometheus + Grafana monitoring infrastructure.

## Why
Need centralized monitoring to collect metrics from API, Dev, and Prod servers. Grafana dashboard will be embedded into the API site's Usage tab.

## Related Issue
Closes #11