### PR TITLE
[Chore/API] Add FastAPI service to docker-compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -5,4 +5,16 @@ services:
       - "80:80"
     volumes:
       - /app/api/frontend:/usr/share/nginx/html/api:ro
+    depends_on:
+      - api
+    restart: unless-stopped
+
+  api:
+    build:
+      context: /app/api
+      dockerfile: /app/cl/api/fastapi/Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - /app/api/api/.env
     restart: unless-stopped

--- a/api/fastapi/Dockerfile
+++ b/api/fastapi/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY api/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/nginx/nginx.conf
+++ b/api/nginx/nginx.conf
@@ -7,4 +7,14 @@ server {
         index index.html;
         try_files $uri $uri/ /index.html;
     }
+
+    location /api/ {
+        resolver 127.0.0.11 valid=30s;
+        set $backend http://api:8000;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }


### PR DESCRIPTION
## What
- Added FastAPI Dockerfile (`api/fastapi/Dockerfile`) with Python 3.11 + uvicorn
- Added FastAPI service to `api/docker-compose.yml`
- Updated `api/nginx/nginx.conf` to reverse proxy `/api/` to FastAPI container

## Why
- API server needs to run the FastAPI backend alongside the frontend NGINX
- Dockerfile is kept in cl repo to centralize infrastructure config

## Related Issue
- Closes #17