### PR TITLE
[Chore] Update dev docker-compose for backend deployment

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     restart: unless-stopped
 
   be:
-    build: /app/be
+    image: us-east1-docker.pkg.dev/v1-mvp/be-dev/be:latest
     ports:
       - "8080:8080"
+    env_file:
+      - /app/be/.env
     restart: unless-stopped


### PR DESCRIPTION
## What
- Change `be` service from local build (`build: /app/be`) to Artifact Registry image
- Add `env_file` for environment variables

## Why
Backend deployment now builds images in CI and pushes to Artifact Registry. The VM only needs to pull and run, not build locally.

## Related Issue
#22