### PR TITLE
[Chore] Update api docker-compose to use Artifact Registry image

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -13,9 +13,7 @@ services:
     restart: unless-stopped
 
   api:
-    build:
-      context: /app/api
-      dockerfile: /app/cl/api/fastapi/Dockerfile
+    image: us-east1-docker.pkg.dev/v1-mvp/api/api:latest
     ports:
       - "8000:8000"
     env_file:


### PR DESCRIPTION
## What
- Change `api` service from local build to Artifact Registry image (`us-east1-docker.pkg.dev/v1-mvp/api/api:latest`)

## Why
API backend now builds in CI and pushes to Artifact Registry. The VM only needs to pull and run, not build locally.

## Related Issue
#24