### PR TITLE
[Chore] Add MySQL service to api docker-compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -17,7 +17,19 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - /app/api/api/.env
+      - /app/api/.env
+    depends_on:
+      - db
+    restart: unless-stopped
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    env_file:
+      - /app/api/.env
+    volumes:
+      - mysql-data:/var/lib/mysql
     restart: unless-stopped
 
   certbot:
@@ -31,3 +43,4 @@ services:
 volumes:
   certbot-webroot:
   certbot-certs:
+  mysql-data:


### PR DESCRIPTION
## What
- Add MySQL 8.0 service to `api/docker-compose.yml`
- Unify env_file path to `/app/api/.env` for both api and db services
- Add persistent volume for MySQL data

## Why
API server needs a database for user management and API key storage. Unified env_file simplifies configuration.

## Related Issue
#26