### PR TITLE
[Chore] Add backend service to api docker-compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -22,6 +22,16 @@ services:
       - db
     restart: unless-stopped
 
+  backend:
+    image: us-east1-docker.pkg.dev/v1-mvp/api/backend:latest
+    ports:
+      - "8001:8000"
+    env_file:
+      - /app/api/.env
+    depends_on:
+      - db
+    restart: unless-stopped
+
   db:
     image: mysql:8.0
     ports:

--- a/api/nginx/nginx.conf
+++ b/api/nginx/nginx.conf
@@ -36,4 +36,14 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location /auth/ {
+        resolver 127.0.0.11 valid=30s;
+        set $backend http://backend:8000;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }


### PR DESCRIPTION
## What
- Add backend service (auth/API key management) to `api/docker-compose.yml`
- Add nginx proxy for `/auth/` routes to backend service

## Why
Backend service handles Google OAuth login and API key management. Nginx needs to route `/auth/` requests to the backend container.

## Related Issue
#28