### PR TITLE
chore: add backend service with nginx auth proxy

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
 
   backend:
-    image: us-east1-docker.pkg.dev/v1-mvp/api/backend:latest
+    image: us-east1-docker.pkg.dev/v1-mvp/be-api/backend:latest
     ports:
       - "8001:8000"
     env_file:


### PR DESCRIPTION
## Summary
- Add backend (auth) service to docker-compose with `be-api` registry image
- Add `/auth/` location block in nginx to proxy to backend service
- Add MySQL service and unify env_file path

## Test plan
- [x] Verify `docker compose up -d` starts backend and db services
- [x] Verify nginx proxies `/auth/` requests to backend
- [x] Verify backend image pulls from `us-east1-docker.pkg.dev/v1-mvp/be-api/backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)