### PR TITLE
fix: update nginx auth proxy path to /api/auth/

### DIFF
--- a/api/nginx/nginx.conf
+++ b/api/nginx/nginx.conf
@@ -37,7 +37,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /auth/ {
+    location /api/auth/ {
         resolver 127.0.0.11 valid=30s;
         set $backend http://backend:8000;
         proxy_pass $backend;


### PR DESCRIPTION
## What
Changed nginx proxy location from `/auth/` to `/api/auth/` in `api/nginx/nginx.conf`.

## Why
The `/auth/` location conflicts with the frontend route `/auth`. When users refresh on `/auth`, nginx proxies the request to the backend instead of serving the React app, resulting in a 404 JSON response.

## Related Issue
Closes #31
Related: Ppa-Dun-project/PPA-DUN-api#27, Ppa-Dun-project/PPA-DUN-api#28