### PR TITLE
[Chore] Add Promtail and Node Exporter to dev server

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     depends_on:
       - be
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   be:
     image: us-east1-docker.pkg.dev/v1-mvp/be-dev/be:latest
@@ -16,3 +21,33 @@ services:
     env_file:
       - /app/be/.env
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    restart: unless-stopped
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/config.yml
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yml

--- a/dev/promtail/promtail-config.yml
+++ b/dev/promtail/promtail-config.yml
@@ -1,0 +1,29 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://10.40.0.2:3100/loki/api/v1/push  # TODO: update with actual Monitoring server IP
+
+scrape_configs:
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          env: dev
+          __path__: /var/lib/docker/containers/*/*-json.log
+
+    pipeline_stages:
+      - docker: {}
+
+      - match:
+          selector: '{job="docker"}'
+          stages:
+            - regex:
+                expression: '.*(?P<level>(ERROR|WARN|INFO|DEBUG)).*'
+            - labels:
+                level:


### PR DESCRIPTION
## What

- Add Promtail container for Docker log collection
- Add Promtail config file (`promtail/promtail-config.yml`)
- Add Node Exporter container for system metrics
- Configure json-file logging driver for fe/be containers

## Why

To enable log collection (via Promtail → Loki) and system metrics monitoring (via Node Exporter → Prometheus) on the dev server.

## Related Issue

closes #34