### PR TITLE
[Chore] Add Grafana dashboard for V1 Dev Server

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/etc/grafana/dashboards
     environment:
       - GF_SECURITY_ALLOW_EMBEDDING=true
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/monitoring/grafana/dashboards/v1-dev-server.json
+++ b/monitoring/grafana/dashboards/v1-dev-server.json
@@ -1,0 +1,203 @@
+{
+  "dashboard": {
+    "title": "V1 Dev Server",
+    "tags": ["dev", "v1"],
+    "timezone": "browser",
+    "refresh": "30s",
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "panels": [
+      {
+        "title": "CPU Usage (%)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 70 },
+                { "color": "red", "value": 90 }
+              ]
+            }
+          }
+        },
+        "targets": [
+          {
+            "expr": "100 - (avg(rate(node_cpu_seconds_total{server=\"dev\", mode=\"idle\"}[5m])) * 100)",
+            "legendFormat": "CPU Usage"
+          }
+        ]
+      },
+      {
+        "title": "Memory Usage (%)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 70 },
+                { "color": "red", "value": 90 }
+              ]
+            }
+          }
+        },
+        "targets": [
+          {
+            "expr": "(1 - node_memory_MemAvailable_bytes{server=\"dev\"} / node_memory_MemTotal_bytes{server=\"dev\"}) * 100",
+            "legendFormat": "Memory Usage"
+          }
+        ]
+      },
+      {
+        "title": "Disk Usage (%)",
+        "type": "gauge",
+        "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 70 },
+                { "color": "red", "value": 85 }
+              ]
+            }
+          }
+        },
+        "targets": [
+          {
+            "expr": "(1 - node_filesystem_avail_bytes{server=\"dev\", mountpoint=\"/\"} / node_filesystem_size_bytes{server=\"dev\", mountpoint=\"/\"}) * 100",
+            "legendFormat": "Disk Usage"
+          }
+        ]
+      },
+      {
+        "title": "Network Traffic",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 6, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "Bps"
+          },
+          "overrides": [
+            {
+              "matcher": { "id": "byName", "options": "Inbound" },
+              "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+            },
+            {
+              "matcher": { "id": "byName", "options": "Outbound" },
+              "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+            }
+          ]
+        },
+        "targets": [
+          {
+            "expr": "rate(node_network_receive_bytes_total{server=\"dev\", device!=\"lo\"}[5m])",
+            "legendFormat": "Inbound"
+          },
+          {
+            "expr": "rate(node_network_transmit_bytes_total{server=\"dev\", device!=\"lo\"}[5m])",
+            "legendFormat": "Outbound"
+          }
+        ]
+      },
+      {
+        "title": "System Load (1m / 5m / 15m)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "targets": [
+          {
+            "expr": "node_load1{server=\"dev\"}",
+            "legendFormat": "1m"
+          },
+          {
+            "expr": "node_load5{server=\"dev\"}",
+            "legendFormat": "5m"
+          },
+          {
+            "expr": "node_load15{server=\"dev\"}",
+            "legendFormat": "15m"
+          }
+        ]
+      },
+      {
+        "title": "Container Logs",
+        "type": "logs",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
+        "datasource": { "type": "loki" },
+        "targets": [
+          {
+            "expr": "{job=\"docker\"}",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "showTime": true,
+          "sortOrder": "Descending",
+          "enableLogDetails": true,
+          "wrapLogMessage": true
+        }
+      },
+      {
+        "title": "Error Logs",
+        "type": "logs",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 26 },
+        "datasource": { "type": "loki" },
+        "targets": [
+          {
+            "expr": "{job=\"docker\"} |~ \"(?i)(error|exception|fatal|traceback)\"",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "showTime": true,
+          "sortOrder": "Descending",
+          "enableLogDetails": true,
+          "wrapLogMessage": true
+        }
+      },
+      {
+        "title": "Error Count (5m)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 36 },
+        "datasource": { "type": "loki" },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 5 },
+                { "color": "red", "value": 20 }
+              ]
+            }
+          }
+        },
+        "targets": [
+          {
+            "expr": "count_over_time({job=\"docker\"} |~ \"(?i)(error|exception|fatal)\" [5m])",
+            "refId": "A"
+          }
+        ]
+      }
+    ]
+  },
+  "overwrite": true
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -8,5 +8,5 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /etc/grafana/dashboards
       foldersFromFilesStructure: false


### PR DESCRIPTION
## What

- Add provisioned Grafana dashboard JSON (`grafana/dashboards/v1-dev-server.json`)
- Update dashboard provisioning path to `/etc/grafana/dashboards`
- Mount dashboards directory in Grafana container

## Why

To monitor V1 Dev Server system metrics (CPU, Memory, Disk, Network, Load) and Docker container logs (including error filtering) from Grafana.

## Related Issue

closes #37