### PR TITLE
Block dotfile requests (.env, .git) in Nginx

### DIFF
--- a/dev/nginx/nginx.conf
+++ b/dev/nginx/nginx.conf
@@ -3,6 +3,12 @@ server {
     listen 80;
     server_name dev.ppa-dun.site;
 
+    # Block dotfile requests (.env, .git, etc.)
+    location ~ /\. {
+        deny all;
+        return 403;
+    }
+
     location / {
         root /usr/share/nginx/html/fe;
         index index.html;


### PR DESCRIPTION
## What
Add a `location ~ /\.` block to the dev Nginx config to deny all dotfile requests and return 403.

## Why
External scanners have been probing `.env`, `.git/config`, and other dotfiles. Due to the SPA `try_files` fallback, these requests were returning `index.html` (200) instead of being rejected. This change ensures dotfile paths are explicitly blocked before reaching the SPA fallback.

## Related Issue
Closes #40