### PR TITLE
fix: add nginx proxy routes for API endpoints

### DIFF
--- a/api/nginx/nginx.conf
+++ b/api/nginx/nginx.conf
@@ -27,6 +27,36 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /health {
+        resolver 127.0.0.11 valid=30s;
+        set $backend http://api:8000;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /demo/ {
+        resolver 127.0.0.11 valid=30s;
+        set $backend http://api:8000;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /player {
+        resolver 127.0.0.11 valid=30s;
+        set $backend http://api:8000;
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         resolver 127.0.0.11 valid=30s;
         set $backend http://api:8000;


### PR DESCRIPTION
## Summary
- Add nginx proxy routes for `/health`, `/demo/`, `/player` endpoints to the API server
- Previously these paths fell through to the frontend `index.html` instead of reaching the API container

Closes #42

## Verification
```bash
curl https://api.ppa-dun.site/health
# Expected: {"status": "ok"}
```