### PR TITLE
Chore: Terraform GKE infrastructure setup

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+.terraform.lock.hcl

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,0 +1,13 @@
+resource "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = var.region
+
+  enable_autopilot = true
+
+  network    = google_compute_network.vpc.id
+  subnetwork = google_compute_subnetwork.subnet.id
+
+  ip_allocation_policy {}
+
+  deletion_protection = false
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = google_container_cluster.primary.name
+}
+
+output "cluster_endpoint" {
+  description = "GKE cluster endpoint"
+  value       = google_container_cluster.primary.endpoint
+  sensitive   = true
+}
+
+output "cluster_location" {
+  description = "GKE cluster location"
+  value       = google_container_cluster.primary.location
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "v1-mvp"
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-east1"
+}
+
+variable "cluster_name" {
+  description = "GKE cluster name"
+  type        = string
+  default     = "ppa-dun-cluster"
+}
+
+variable "vpc_name" {
+  description = "VPC network name"
+  type        = string
+  default     = "vpc-gke"
+}
+
+variable "subnet_name" {
+  description = "Subnet name"
+  type        = string
+  default     = "subnet-gke"
+}
+
+variable "subnet_cidr" {
+  description = "Subnet CIDR range"
+  type        = string
+  default     = "10.50.0.0/20"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,11 @@
+resource "google_compute_network" "vpc" {
+  name                    = var.vpc_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = var.subnet_name
+  ip_cidr_range = var.subnet_cidr
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}


### PR DESCRIPTION
## Summary
- Add Terraform project structure for managing GKE infrastructure
- Create VPC (`vpc-gke`) and subnet (`subnet-gke`, `10.50.0.0/20`)
- Create GKE Autopilot cluster (`ppa-dun-cluster`) in `us-east1`

Closes #44

## Test plan
- [x] `terraform apply` successfully creates VPC and subnet
- [x] `terraform apply` successfully creates GKE Autopilot cluster
- [x] `kubectl get nodes` connects to cluster