### PR TITLE
feat: Add MySQL DB to dev server

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -20,6 +20,23 @@ services:
       - "8080:8080"
     env_file:
       - /app/be/.env
+    depends_on:
+      - db
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    env_file:
+      - /app/be/.env
+    volumes:
+      - mysql-data:/var/lib/mysql
     restart: unless-stopped
     logging:
       driver: json-file
@@ -51,3 +68,6 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.yml
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## Summary
- Add MySQL service to cl/dev/docker-compose.yml with persistent volume
- Enables dev server to have its own local database for Google login implementation

Closes #49

## Test plan
- [ ] Merge to infra/helm-chart-setup
- [ ] SSH into dev server and run docker compose up -d db
- [ ] Verify MySQL container is running and BE can connect