### PR TITLE
feat: Add HTTPS/SSL to dev server

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -3,8 +3,11 @@ services:
     build: ./nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - /app/fe/dist:/usr/share/nginx/html/fe:ro
+      - certbot-webroot:/var/www/certbot:ro
+      - certbot-certs:/etc/letsencrypt:ro
     depends_on:
       - be
     restart: unless-stopped
@@ -13,6 +16,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - certbot-webroot:/var/www/certbot
+      - certbot-certs:/etc/letsencrypt
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done'"
+    restart: unless-stopped
 
   be:
     image: us-east1-docker.pkg.dev/v1-mvp/be-dev/be:latest
@@ -71,3 +82,5 @@ services:
 
 volumes:
   mysql-data:
+  certbot-webroot:
+  certbot-certs:

--- a/dev/nginx/nginx.conf
+++ b/dev/nginx/nginx.conf
@@ -1,7 +1,24 @@
-# FE (React app)
+# HTTP → HTTPS redirect + Certbot challenge
 server {
     listen 80;
     server_name dev.ppa-dun.site;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS
+server {
+    listen 443 ssl;
+    server_name dev.ppa-dun.site;
+
+    ssl_certificate /etc/letsencrypt/live/dev.ppa-dun.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.ppa-dun.site/privkey.pem;
 
     # Block dotfile requests (.env, .git, etc.)
     location ~ /\. {


### PR DESCRIPTION
## Summary
- Add HTTPS server block to cl/dev/nginx/nginx.conf with HTTP→HTTPS redirect
- Add port 443 mapping and certbot service to cl/dev/docker-compose.yml
- Mount certbot-webroot and certbot-certs volumes
- Let's Encrypt certificate already issued on dev server (expires 2026-07-16)

Closes #51

## Test plan
- [ ] Merge to infra/helm-chart-setup
- [ ] SSH into dev server, pull latest, and run docker compose up -d
- [ ] Verify https://dev.ppa-dun.site loads