### PR TITLE
feat: Restore dedicated ppa-dun DB for prod

### DIFF
--- a/helm/ppa-dun/templates/ppa-dun-db-deployment.yaml
+++ b/helm/ppa-dun/templates/ppa-dun-db-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ppa-dun-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ppa-dun-db
+  template:
+    metadata:
+      labels:
+        app: ppa-dun-db
+    spec:
+      volumes:
+        - name: mysql-data
+          persistentVolumeClaim:
+            claimName: ppa-dun-db-pvc
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          ports:
+            - containerPort: 3306
+          envFrom:
+            - secretRef:
+                name: ppa-dun-secret
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql

--- a/helm/ppa-dun/templates/ppa-dun-db-pvc.yaml
+++ b/helm/ppa-dun/templates/ppa-dun-db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ppa-dun-db-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/helm/ppa-dun/templates/ppa-dun-db-service.yaml
+++ b/helm/ppa-dun/templates/ppa-dun-db-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ppa-dun-db
+spec:
+  selector:
+    app: ppa-dun-db
+  ports:
+    - port: 3306
+      targetPort: 3306


### PR DESCRIPTION
## Summary
- Restore GKE MySQL Pod (deployment, service, PVC) for ppa-dun prod
- Player data will move back to ppa-dun's own DB, not API server

Closes #53