### PR TITLE
fix: block internal-only endpoints at nginx + remove dead /api/ block

### DIFF
--- a/api/nginx/nginx.conf
+++ b/api/nginx/nginx.conf
@@ -21,6 +21,19 @@ server {
     ssl_certificate /etc/letsencrypt/live/api.ppa-dun.site/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/api.ppa-dun.site/privkey.pem;
 
+    # ── Internal-only — block external access ────────────────────────────
+    location /internal/ {
+        return 403;
+    }
+
+    location /player/recalculate {
+        return 403;
+    }
+
+    location /admin/ {
+        return 403;
+    }
+
     location / {
         root /usr/share/nginx/html/api;
         index index.html;
@@ -57,27 +70,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /api/ {
-        resolver 127.0.0.11 valid=30s;
-        set $backend http://api:8000;
-        proxy_pass $backend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     location /api/auth/ {
-        resolver 127.0.0.11 valid=30s;
-        set $backend http://backend:8000;
-        proxy_pass $backend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /admin/ {
         resolver 127.0.0.11 valid=30s;
         set $backend http://backend:8000;
         proxy_pass $backend;


### PR DESCRIPTION
## What
Add nginx 403 blocks for three internal-only endpoints and remove the dead \`/api/\` proxy.

Added:
\`\`\`nginx
location /internal/           { return 403; }
location /player/recalculate  { return 403; }
location /admin/              { return 403; }
\`\`\`

Removed:
- \`location /api/\` proxy (no endpoints exist under \`/api/*\` in api/backend services; \`/api/auth/*\` has its own block)
- old \`location /admin/\` proxy (replaced by the 403 block above)

## Why
- \`/player/recalculate\` was caught by \`location /player\` prefix and proxied externally. The api middleware also exempts it from API key auth → anyone could hit the internal stub.
- \`/internal/reload-baselines\` was only rejected \"by accident\" via the static fallback returning 405. The api middleware exempts \`/internal/*\` from API key auth too → needed an explicit block.
- \`/admin/update\` on backend has no auth; exposing it externally lets anyone trigger the daily ESPN-scrape pipeline. Defense-in-depth at nginx for now; backend auth can be added later as a separate issue.
- \`/api/\` prefix block: searched every branch on the api repo — no endpoints under \`/api/*\` except \`/api/auth/*\` which already has its own block. Dead config.

Longest-prefix-wins ensures \`/player/recalculate\` (20 chars) overrides \`/player\` (7 chars). Internal Docker network calls (\`backend\` → \`http://api:8000/...\`) don't traverse nginx, so internal functionality is unaffected.

## Related Issue
Closes #56